### PR TITLE
Change harfbuzz dep to v1.3.0

### DIFF
--- a/scripts/mapnik/3.0.15-carto/script.sh
+++ b/scripts/mapnik/3.0.15-carto/script.sh
@@ -59,7 +59,7 @@ function mason_prepare_compile {
     install boost_libprogram_options 1.63.0
     install boost_libregex_icu57 1.63.0
     install freetype 2.7.1 libfreetype
-    install harfbuzz 1.4.2-ft libharfbuzz
+    install harfbuzz 1.3.0 libharfbuzz
 }
 
 function mason_compile {


### PR DESCRIPTION
@skgsergio I think that in order to build node-mapnik against harfbuzz v1.3.0 I'd need to merge this, so unless you're strongly opposed I'll go ahead as soon as I can.